### PR TITLE
Reordering technical skill tabs in the form

### DIFF
--- a/api/index.tsx
+++ b/api/index.tsx
@@ -4,7 +4,7 @@ import type { SkillResponse } from "../components/types";
 export async function fetchSkills() {
   const { data } = await supabase
     .from("skill")
-    .select("id, name, skill_group(id, name)")
+    .select("id, name, skill_group(id, name, order)")
     .order("name")
     .returns<SkillResponse>();
 

--- a/components/cv_form/skills_tab.tsx
+++ b/components/cv_form/skills_tab.tsx
@@ -3,16 +3,20 @@ import type { FieldArrayRenderProps } from "formik";
 import { FieldArray } from "formik";
 import Checkbox from "@ui/checkbox";
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@ui/tab";
+import type { SkillGroup } from "../types";
 
 interface SkillsTabProps {
   fProps: any;
-  skills: {
-    [key: string]: {
-      group_name: string;
-      skills: Array<{ id: string; name: string }>;
-    };
-  };
+  skills: SkillGroup;
 }
+
+const ORDERED_SKILL_GROUPS = [
+  "Programming languages",
+  "Libs & Frameworks",
+  "Tools & Enviroments",
+  "Databases",
+  "Project Management",
+];
 
 export default function SkillsTab({ fProps, skills }: SkillsTabProps) {
   const isChecked = (skill: { id: string; name: string }) =>
@@ -36,37 +40,42 @@ export default function SkillsTab({ fProps, skills }: SkillsTabProps) {
     }
   };
 
+  console.log(skills);
+  console.log(skills["Libs & Frameworks"]);
+
   return (
     <TabGroup>
       <TabList>
-        {Object.entries(skills).map(([id, group]) => (
-          <Tab key={id}>{group.group_name}</Tab>
-        ))}
+        {ORDERED_SKILL_GROUPS.map((orderedSkillGroupName) => {
+          return <Tab key={orderedSkillGroupName}>{orderedSkillGroupName}</Tab>;
+        })}
       </TabList>
       <TabPanels>
         <FieldArray
           name="cv_skill"
           render={(arrayHelpers) => (
             <>
-              {Object.entries(skills).map(([id, group]) => (
-                <TabPanel
-                  className="grid gap-3 px-1.5 sm:grid-cols-2 md:grid-cols-3 md:gap-4 lg:grid-cols-4"
-                  key={id}
-                >
-                  {group.skills.map((skill) => (
-                    <Checkbox
-                      checked={isChecked(skill)}
-                      key={skill.id}
-                      name={"cv_skill-" + skill.id}
-                      onChange={(event) =>
-                        onChangeHandler(event, arrayHelpers, skill)
-                      }
-                    >
-                      {skill.name}
-                    </Checkbox>
-                  ))}
-                </TabPanel>
-              ))}
+              {ORDERED_SKILL_GROUPS.map((orderedSkillGroupName) => {
+                return (
+                  <TabPanel
+                    className="grid gap-3 px-1.5 sm:grid-cols-2 md:grid-cols-3 md:gap-4 lg:grid-cols-4"
+                    key={orderedSkillGroupName}
+                  >
+                    {skills[orderedSkillGroupName].map((skill) => (
+                      <Checkbox
+                        checked={isChecked(skill)}
+                        key={skill.id}
+                        name={"cv_skill-" + skill.id}
+                        onChange={(event) =>
+                          onChangeHandler(event, arrayHelpers, skill)
+                        }
+                      >
+                        {skill.name}
+                      </Checkbox>
+                    ))}
+                  </TabPanel>
+                );
+              })}
             </>
           )}
         />

--- a/components/cv_form/skills_tab.tsx
+++ b/components/cv_form/skills_tab.tsx
@@ -3,7 +3,7 @@ import type { FieldArrayRenderProps } from "formik";
 import { FieldArray } from "formik";
 import Checkbox from "@ui/checkbox";
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@ui/tab";
-import type { SkillGroup, Skill } from "../types";
+import type { SkillGroup, Skill, CvSkillResponse } from "../types";
 
 interface SkillsTabProps {
   fProps: any;
@@ -11,22 +11,21 @@ interface SkillsTabProps {
 }
 
 export default function SkillsTab({ fProps, skills }: SkillsTabProps) {
-  const isChecked = (skill: { id: string; name: string }) =>
+  const isChecked = (skill: Skill) =>
     fProps.values.cv_skill.some(
-      (cvSkill: { id?: string; skill_id: string; cv_id?: string }) =>
-        cvSkill.skill_id === skill.id,
+      (cvSkill: CvSkillResponse) => cvSkill.skill_id === skill.id,
     );
 
   const onChangeHandler = (
     event: ChangeEvent<HTMLInputElement>,
     arrayHelpers: FieldArrayRenderProps,
-    skill: { id: string; name: string },
+    skill: Skill,
   ) => {
     if (event.target.checked) {
       arrayHelpers.push({ skill_id: skill.id });
     } else {
       const index = fProps.values.cv_skill.findIndex(
-        (cvSkill: any) => cvSkill.skill_id === skill.id,
+        (cvSkill: CvSkillResponse) => cvSkill.skill_id === skill.id,
       );
       arrayHelpers.remove(index);
     }
@@ -35,7 +34,7 @@ export default function SkillsTab({ fProps, skills }: SkillsTabProps) {
   return (
     <TabGroup>
       <TabList>
-        {Object.entries(skills).map(([_, skillGroup]) => (
+        {Object.values(skills).map((skillGroup: SkillGroup[number]) => (
           <Tab key={skillGroup.group_name}>{skillGroup.group_name}</Tab>
         ))}
       </TabList>
@@ -44,12 +43,12 @@ export default function SkillsTab({ fProps, skills }: SkillsTabProps) {
           name="cv_skill"
           render={(arrayHelpers) => (
             <>
-              {Object.entries(skills).map(([_, skillGroup]) => (
+              {Object.values(skills).map((skillGroup: SkillGroup[number]) => (
                 <TabPanel
                   className="grid gap-3 px-1.5 sm:grid-cols-2 md:grid-cols-3 md:gap-4 lg:grid-cols-4"
                   key={skillGroup.group_name}
                 >
-                  {skillGroup.skills.map((skill: Skill) => (
+                  {skillGroup.skills.map((skill) => (
                     <Checkbox
                       checked={isChecked(skill)}
                       key={skill.id}

--- a/components/cv_form/skills_tab.tsx
+++ b/components/cv_form/skills_tab.tsx
@@ -43,36 +43,34 @@ export default function SkillsTab({ fProps, skills }: SkillsTabProps) {
   return (
     <TabGroup>
       <TabList>
-        {ORDERED_SKILL_GROUPS.map((orderedSkillGroupName) => {
-          return <Tab key={orderedSkillGroupName}>{orderedSkillGroupName}</Tab>;
-        })}
+        {ORDERED_SKILL_GROUPS.map((orderedSkillGroupName) => (
+          <Tab key={orderedSkillGroupName}>{orderedSkillGroupName}</Tab>
+        ))}
       </TabList>
       <TabPanels>
         <FieldArray
           name="cv_skill"
           render={(arrayHelpers) => (
             <>
-              {ORDERED_SKILL_GROUPS.map((orderedSkillGroupName) => {
-                return (
-                  <TabPanel
-                    className="grid gap-3 px-1.5 sm:grid-cols-2 md:grid-cols-3 md:gap-4 lg:grid-cols-4"
-                    key={orderedSkillGroupName}
-                  >
-                    {skills[orderedSkillGroupName].map((skill) => (
-                      <Checkbox
-                        checked={isChecked(skill)}
-                        key={skill.id}
-                        name={"cv_skill-" + skill.id}
-                        onChange={(event) =>
-                          onChangeHandler(event, arrayHelpers, skill)
-                        }
-                      >
-                        {skill.name}
-                      </Checkbox>
-                    ))}
-                  </TabPanel>
-                );
-              })}
+              {ORDERED_SKILL_GROUPS.map((orderedSkillGroupName) => (
+                <TabPanel
+                  className="grid gap-3 px-1.5 sm:grid-cols-2 md:grid-cols-3 md:gap-4 lg:grid-cols-4"
+                  key={orderedSkillGroupName}
+                >
+                  {skills[orderedSkillGroupName].map((skill) => (
+                    <Checkbox
+                      checked={isChecked(skill)}
+                      key={skill.id}
+                      name={"cv_skill-" + skill.id}
+                      onChange={(event) =>
+                        onChangeHandler(event, arrayHelpers, skill)
+                      }
+                    >
+                      {skill.name}
+                    </Checkbox>
+                  ))}
+                </TabPanel>
+              ))}
             </>
           )}
         />

--- a/components/cv_form/skills_tab.tsx
+++ b/components/cv_form/skills_tab.tsx
@@ -40,9 +40,6 @@ export default function SkillsTab({ fProps, skills }: SkillsTabProps) {
     }
   };
 
-  console.log(skills);
-  console.log(skills["Libs & Frameworks"]);
-
   return (
     <TabGroup>
       <TabList>

--- a/components/cv_form/skills_tab.tsx
+++ b/components/cv_form/skills_tab.tsx
@@ -3,20 +3,12 @@ import type { FieldArrayRenderProps } from "formik";
 import { FieldArray } from "formik";
 import Checkbox from "@ui/checkbox";
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@ui/tab";
-import type { SkillGroup } from "../types";
+import type { SkillGroup, Skill } from "../types";
 
 interface SkillsTabProps {
   fProps: any;
   skills: SkillGroup;
 }
-
-const ORDERED_SKILL_GROUPS = [
-  "Programming languages",
-  "Libs & Frameworks",
-  "Tools & Enviroments",
-  "Databases",
-  "Project Management",
-];
 
 export default function SkillsTab({ fProps, skills }: SkillsTabProps) {
   const isChecked = (skill: { id: string; name: string }) =>
@@ -43,8 +35,8 @@ export default function SkillsTab({ fProps, skills }: SkillsTabProps) {
   return (
     <TabGroup>
       <TabList>
-        {ORDERED_SKILL_GROUPS.map((orderedSkillGroupName) => (
-          <Tab key={orderedSkillGroupName}>{orderedSkillGroupName}</Tab>
+        {Object.entries(skills).map(([_, skillGroup]) => (
+          <Tab key={skillGroup.group_name}>{skillGroup.group_name}</Tab>
         ))}
       </TabList>
       <TabPanels>
@@ -52,12 +44,12 @@ export default function SkillsTab({ fProps, skills }: SkillsTabProps) {
           name="cv_skill"
           render={(arrayHelpers) => (
             <>
-              {ORDERED_SKILL_GROUPS.map((orderedSkillGroupName) => (
+              {Object.entries(skills).map(([_, skillGroup]) => (
                 <TabPanel
                   className="grid gap-3 px-1.5 sm:grid-cols-2 md:grid-cols-3 md:gap-4 lg:grid-cols-4"
-                  key={orderedSkillGroupName}
+                  key={skillGroup.group_name}
                 >
-                  {skills[orderedSkillGroupName].map((skill) => (
+                  {skillGroup.skills.map((skill: Skill) => (
                     <Checkbox
                       checked={isChecked(skill)}
                       key={skill.id}

--- a/components/cv_form/technical_skill.tsx
+++ b/components/cv_form/technical_skill.tsx
@@ -1,16 +1,13 @@
+import { SkillGroup } from "../types";
 import SkillsTab from "./skills_tab";
 
 interface Props {
   fProps: any;
-  skills: {
-    [key: string]: {
-      group_name: string;
-      skills: Array<{ id: string; name: string }>;
-    };
-  };
+  skills: SkillGroup;
 }
 
 export default function TechnicalSkill({ fProps, skills }: Props) {
+  console.log(skills);
   return (
     <div>
       <h2 className="my-10 text-2xl font-bold dark:text-gray-300">

--- a/components/cv_form/technical_skill.tsx
+++ b/components/cv_form/technical_skill.tsx
@@ -7,7 +7,6 @@ interface Props {
 }
 
 export default function TechnicalSkill({ fProps, skills }: Props) {
-  console.log(skills);
   return (
     <div>
       <h2 className="my-10 text-2xl font-bold dark:text-gray-300">

--- a/components/cv_form/technical_skill.tsx
+++ b/components/cv_form/technical_skill.tsx
@@ -1,5 +1,5 @@
-import { SkillGroup } from "../types";
 import SkillsTab from "./skills_tab";
+import type { SkillGroup } from "../types";
 
 interface Props {
   fProps: any;

--- a/components/types.d.ts
+++ b/components/types.d.ts
@@ -6,7 +6,7 @@ interface CvSkillResponse {
   id: string;
   cv_id: string;
   skill_id: string;
-};
+}
 
 interface SkillResponse {
   id: string;
@@ -23,10 +23,7 @@ interface Skill {
 }
 
 interface SkillGroup {
-  [group_id: string]: {
-    group_name: string;
-    skills: Array<Skill>;
-  };
+  [group_name: string]: Array<Skill>;
 }
 
 export interface CV {

--- a/components/types.d.ts
+++ b/components/types.d.ts
@@ -26,7 +26,7 @@ interface Skill {
 interface SkillGroup {
   [order: number]: {
     group_name: string;
-    skills: Array<Skill>
+    skills: Array<Skill>;
   };
 }
 

--- a/components/types.d.ts
+++ b/components/types.d.ts
@@ -24,7 +24,10 @@ interface Skill {
 }
 
 interface SkillGroup {
-  [order: number]: { group_name: string; skills: Array<Skill> };
+  [order: number]: {
+    group_name: string;
+    skills: Array<Skill>
+  };
 }
 
 export interface CV {

--- a/components/types.d.ts
+++ b/components/types.d.ts
@@ -14,6 +14,7 @@ interface SkillResponse {
   skill_group: {
     id: string;
     name: string;
+    order: number;
   };
 }
 
@@ -23,7 +24,7 @@ interface Skill {
 }
 
 interface SkillGroup {
-  [group_name: string]: Array<Skill>;
+  [order: number]: { group_name: string; skills: Array<Skill> };
 }
 
 export interface CV {

--- a/helpers/index.tsx
+++ b/helpers/index.tsx
@@ -4,13 +4,13 @@ export function transformSkills(response: SkillResponse[] | null) {
   if (response == null) return {};
 
   return response.reduce<SkillGroup>((acc, skill) => {
-    const group_name = skill.skill_group.name;
+    const order = skill.skill_group.order;
 
-    if (!acc[group_name]) {
-      acc[group_name] = [];
+    if (!acc[order]) {
+      acc[order] = { group_name: skill.skill_group.name, skills: [] };
     }
 
-    acc[group_name].push({
+    acc[order].skills.push({
       name: skill.name,
       id: skill.id,
     });

--- a/helpers/index.tsx
+++ b/helpers/index.tsx
@@ -7,7 +7,10 @@ export function transformSkills(response: SkillResponse[] | null) {
     const order = skill.skill_group.order;
 
     if (!acc[order]) {
-      acc[order] = { group_name: skill.skill_group.name, skills: [] };
+      acc[order] = {
+        group_name: skill.skill_group.name,
+        skills: [],
+      };
     }
 
     acc[order].skills.push({

--- a/helpers/index.tsx
+++ b/helpers/index.tsx
@@ -4,16 +4,13 @@ export function transformSkills(response: SkillResponse[] | null) {
   if (response == null) return {};
 
   return response.reduce<SkillGroup>((acc, skill) => {
-    const group_id = skill.skill_group.id;
+    const group_name = skill.skill_group.name;
 
-    if (!acc[group_id]) {
-      acc[group_id] = {
-        group_name: skill.skill_group.name,
-        skills: [],
-      };
+    if (!acc[group_name]) {
+      acc[group_name] = [];
     }
 
-    acc[group_id].skills.push({
+    acc[group_name].push({
       name: skill.name,
       id: skill.id,
     });

--- a/supabase/migrations/20230330155932_add_order_column_to_skill_group.sql
+++ b/supabase/migrations/20230330155932_add_order_column_to_skill_group.sql
@@ -1,0 +1,5 @@
+alter table "public"."skill_group" add column "order" smallint unique;
+
+create unique index skill_group_order_key ON "public"."skill_group" USING btree ("order");
+
+alter table "public"."skill_group" add constraint "skill_group_order_key" UNIQUE using index "skill_group_order_key";


### PR DESCRIPTION
Added `order` column to `skill_group` table for custom tab ordering for technical skills in UI.

<img width="1060" alt="image" src="https://user-images.githubusercontent.com/32201336/228859079-3f586633-fc78-4792-94ea-714a65bba9bb.png">
