### PR TITLE
Create input component

### DIFF
--- a/components/cv_form/additional_info.tsx
+++ b/components/cv_form/additional_info.tsx
@@ -1,6 +1,8 @@
 import { Field, FieldArray } from "formik";
 import CvFieldArray from "./cv_field_array";
 import * as Icons from "@ui/icons";
+import Input from "@ui/input";
+import Button from "@ui/button";
 
 interface AdditionalInfoProps {
   formProps: any;
@@ -35,21 +37,23 @@ export function AdditionalInfo({
                         <div key={index} className="py-2">
                           <div className="mb-2 flex w-full">
                             <Field
+                              as={Input}
+                              fullWidth
                               name={`certifications.${index}.certificate_name`}
-                              className="mr-1 w-full rounded-md border border-gray-500 p-1 dark:bg-white"
-                              placeholder="name"
+                              placeholder="Certificate name"
                             />
                           </div>
                           <div className="mb-2 flex w-full">
                             <Field
+                              as={Input}
+                              fullWidth
                               name={`certifications.${index}.description`}
-                              className="mr-1 w-full rounded-md border border-gray-500 p-1 dark:bg-white"
-                              placeholder="description"
+                              placeholder="Certificate description"
                             />
                           </div>
-                          <button
-                            className="float-right rounded-md border border-indigo-500 bg-indigo-500 p-1 text-white"
-                            type="button"
+                          <Button
+                            className="ml-auto"
+                            variant="outlined"
                             onClick={() => {
                               arrayHelpers.remove(index);
                               setCertificationsToRemove((prevIds) => [
@@ -57,16 +61,17 @@ export function AdditionalInfo({
                                 certification.id,
                               ]);
                             }}
+                            prefix={<Icons.TrashCan className="h-5 w-5" />}
                           >
-                            <Icons.TrashCan />
-                          </button>
+                            Remove certificate
+                          </Button>
                         </div>
                       ),
                     )}
                   <button
                     type="button"
                     onClick={() => arrayHelpers.push("")}
-                    className="flex text-indigo-500"
+                    className="flex gap-1 text-indigo-500"
                   >
                     <Icons.PlusCircle />
                     <span>Add</span>

--- a/components/cv_form/additional_info.tsx
+++ b/components/cv_form/additional_info.tsx
@@ -38,6 +38,7 @@ export function AdditionalInfo({
                           <div className="mb-2 flex w-full">
                             <Field
                               as={Input}
+                              autoFocus
                               fullWidth
                               name={`certifications.${index}.certificate_name`}
                               placeholder="Certificate name"

--- a/components/cv_form/cv_field_array.tsx
+++ b/components/cv_form/cv_field_array.tsx
@@ -1,5 +1,8 @@
 import { Field, FieldArray } from "formik";
 import * as Icons from "@ui/icons";
+import type { PrefixSuffixRenderProps } from "@ui/input";
+import Input from "@ui/input";
+import RemoveInputAction from "./remove_input_action";
 
 interface Props {
   fProps: any;
@@ -26,22 +29,22 @@ export default function CvFieldArray({ fProps, title, fieldArrayName }: Props) {
                 fProps.values[fieldArrayName].map((item: any, index: any) => (
                   <div key={index} className="mb-2 flex w-full">
                     <Field
+                      as={Input}
+                      fullWidth
                       name={`${fieldArrayName}.${index}`}
-                      className="mr-1 w-full rounded-md border border-gray-500 p-1 dark:bg-white"
+                      renderSuffix={({ disabled }: PrefixSuffixRenderProps) => (
+                        <RemoveInputAction
+                          disabled={disabled}
+                          onClick={() => arrayHelpers.remove(index)}
+                        />
+                      )}
                     />
-                    <button
-                      className="rounded-md border border-indigo-500 bg-indigo-500 p-1  text-white"
-                      type="button"
-                      onClick={() => arrayHelpers.remove(index)}
-                    >
-                      <Icons.TrashCan />
-                    </button>
                   </div>
                 ))}
               <button
                 type="button"
                 onClick={() => arrayHelpers.push("")}
-                className="flex text-indigo-500"
+                className="flex gap-1 text-indigo-500"
               >
                 <Icons.PlusCircle />
                 <span>Add</span>

--- a/components/cv_form/cv_field_array.tsx
+++ b/components/cv_form/cv_field_array.tsx
@@ -30,6 +30,7 @@ export default function CvFieldArray({ fProps, title, fieldArrayName }: Props) {
                   <div key={index} className="mb-2 flex w-full">
                     <Field
                       as={Input}
+                      autoFocus
                       fullWidth
                       name={`${fieldArrayName}.${index}`}
                       renderSuffix={({ disabled }: PrefixSuffixRenderProps) => (

--- a/components/cv_form/education.tsx
+++ b/components/cv_form/education.tsx
@@ -2,6 +2,7 @@ import { Field, FieldArray } from "formik";
 import * as Icons from "@ui/icons";
 
 import * as Options from "../../constants/CvFormOptions";
+import Input, { inputClasses } from "@ui/input";
 
 interface EducationProps {
   fProps: any;
@@ -33,10 +34,10 @@ export function Education({ fProps, setEducationsToRemove }: EducationProps) {
                     </div>
                     <div className="md:flex-grow">
                       <Field
-                        className="w-full rounded-md"
+                        as={Input}
                         name={`educations[${educationIndex}].university_name`}
-                        type="text"
                         placeholder="Name of University"
+                        type="text"
                       />
                     </div>
                   </div>
@@ -49,11 +50,11 @@ export function Education({ fProps, setEducationsToRemove }: EducationProps) {
                     </div>
                     <div className="md:flex-grow">
                       <Field
-                        className="w-full rounded-md"
-                        name={`educations[${educationIndex}].degree`}
-                        type="text"
                         as="textarea"
+                        className={inputClasses()}
+                        name={`educations[${educationIndex}].degree`}
                         placeholder="Degree"
+                        type="text"
                       />
                     </div>
                   </div>

--- a/components/cv_form/education.tsx
+++ b/components/cv_form/education.tsx
@@ -51,7 +51,7 @@ export function Education({ fProps, setEducationsToRemove }: EducationProps) {
                     <div className="md:flex-grow">
                       <Field
                         as="textarea"
-                        className={inputClasses()}
+                        className={inputClasses({ className: "text-gray-900" })}
                         name={`educations[${educationIndex}].degree`}
                         placeholder="Degree"
                         type="text"

--- a/components/cv_form/education.tsx
+++ b/components/cv_form/education.tsx
@@ -35,6 +35,7 @@ export function Education({ fProps, setEducationsToRemove }: EducationProps) {
                     <div className="md:flex-grow">
                       <Field
                         as={Input}
+                        autoFocus
                         name={`educations[${educationIndex}].university_name`}
                         placeholder="Name of University"
                         type="text"

--- a/components/cv_form/nested_row.tsx
+++ b/components/cv_form/nested_row.tsx
@@ -30,6 +30,7 @@ export default function NestedRow({
                 <div key={itemIndex} className="mb-2 flex w-full">
                   <Field
                     as={Input}
+                    autoFocus
                     fullWidth
                     name={`[${outerArray}][${outerIndex}][${innerArray}].${itemIndex}`}
                     renderSuffix={({ disabled }: PrefixSuffixRenderProps) => (

--- a/components/cv_form/nested_row.tsx
+++ b/components/cv_form/nested_row.tsx
@@ -1,5 +1,9 @@
+import React from "react";
+import { cx } from "class-variance-authority";
 import { Field, FieldArray } from "formik";
 import * as Icons from "@ui/icons";
+import Input from "@ui/input";
+import Button from "@ui/button";
 
 interface Props {
   fProps: any;
@@ -7,6 +11,26 @@ interface Props {
   outerArray: string;
   innerArray: string;
 }
+
+interface RemoveButtonProps {
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const RemoveInputSuffix = ({ onClick }: RemoveButtonProps) => (
+  <Button
+    className={cx([
+      // add left border and remove radius
+      // + add 1px margin (width of border) so container's border is not overlapped on hover and focus
+      "m-px rounded-l-none border-l border-l-gray-300",
+      "focus:m-0 focus:border focus:border-indigo-300 focus:ring-4 focus:ring-indigo-100",
+    ])}
+    onClick={onClick}
+    variant="plain"
+  >
+    <Icons.TrashCan className="h-5 w-5" />
+    <span className="hidden sm:inline">Remove</span>
+  </Button>
+);
 
 export default function NestedRow({
   fProps,
@@ -25,16 +49,15 @@ export default function NestedRow({
               (item: any, itemIndex: any) => (
                 <div key={itemIndex} className="mb-2 flex w-full">
                   <Field
-                    className="mr-1 w-full rounded-md border border-gray-500 p-1 dark:bg-white"
+                    as={Input}
+                    fullWidth
                     name={`[${outerArray}][${outerIndex}][${innerArray}].${itemIndex}`}
+                    suffix={
+                      <RemoveInputSuffix
+                        onClick={() => arrayHelpers.remove(itemIndex)}
+                      />
+                    }
                   />
-                  <button
-                    className="rounded-md border border-indigo-500 bg-indigo-500 p-1  text-white"
-                    type="button"
-                    onClick={() => arrayHelpers.remove(itemIndex)}
-                  >
-                    <Icons.TrashCan />
-                  </button>
                 </div>
               ),
             )}

--- a/components/cv_form/nested_row.tsx
+++ b/components/cv_form/nested_row.tsx
@@ -43,7 +43,7 @@ export default function NestedRow({
               ),
             )}
           <button
-            className="flex text-indigo-500"
+            className="flex gap-1 text-indigo-500"
             type="button"
             onClick={() => arrayHelpers.push("")}
           >

--- a/components/cv_form/nested_row.tsx
+++ b/components/cv_form/nested_row.tsx
@@ -1,10 +1,9 @@
 import React from "react";
-import { cx } from "class-variance-authority";
 import { Field, FieldArray } from "formik";
 import * as Icons from "@ui/icons";
-import type { PrefixSuffixRenderProps } from "@ui/input";
 import Input from "@ui/input";
-import Button from "@ui/button";
+import RemoveInputAction from "./remove_input_action";
+import type { PrefixSuffixRenderProps } from "@ui/input";
 
 interface Props {
   fProps: any;
@@ -12,28 +11,6 @@ interface Props {
   outerArray: string;
   innerArray: string;
 }
-
-interface RemoveButtonProps {
-  disabled?: boolean;
-  onClick: React.MouseEventHandler<HTMLButtonElement>;
-}
-
-const RemoveInputSuffix = ({ disabled, onClick }: RemoveButtonProps) => (
-  <Button
-    className={cx([
-      // add left border and remove radius
-      // + add 1px margin (width of border) so container's border is not overlapped on hover and focus
-      "m-px rounded-l-none border-l border-l-gray-300",
-      "focus:m-0 focus:border focus:border-indigo-300 focus:ring-4 focus:ring-indigo-100",
-    ])}
-    disabled={disabled}
-    onClick={onClick}
-    variant="plain"
-  >
-    <Icons.TrashCan className="h-5 w-5" />
-    <span className="hidden sm:inline">Remove</span>
-  </Button>
-);
 
 export default function NestedRow({
   fProps,
@@ -56,7 +33,7 @@ export default function NestedRow({
                     fullWidth
                     name={`[${outerArray}][${outerIndex}][${innerArray}].${itemIndex}`}
                     renderSuffix={({ disabled }: PrefixSuffixRenderProps) => (
-                      <RemoveInputSuffix
+                      <RemoveInputAction
                         disabled={disabled}
                         onClick={() => arrayHelpers.remove(itemIndex)}
                       />

--- a/components/cv_form/nested_row.tsx
+++ b/components/cv_form/nested_row.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { cx } from "class-variance-authority";
 import { Field, FieldArray } from "formik";
 import * as Icons from "@ui/icons";
+import type { PrefixSuffixRenderProps } from "@ui/input";
 import Input from "@ui/input";
 import Button from "@ui/button";
 
@@ -13,10 +14,11 @@ interface Props {
 }
 
 interface RemoveButtonProps {
+  disabled?: boolean;
   onClick: React.MouseEventHandler<HTMLButtonElement>;
 }
 
-const RemoveInputSuffix = ({ onClick }: RemoveButtonProps) => (
+const RemoveInputSuffix = ({ disabled, onClick }: RemoveButtonProps) => (
   <Button
     className={cx([
       // add left border and remove radius
@@ -24,6 +26,7 @@ const RemoveInputSuffix = ({ onClick }: RemoveButtonProps) => (
       "m-px rounded-l-none border-l border-l-gray-300",
       "focus:m-0 focus:border focus:border-indigo-300 focus:ring-4 focus:ring-indigo-100",
     ])}
+    disabled={disabled}
     onClick={onClick}
     variant="plain"
   >
@@ -52,11 +55,12 @@ export default function NestedRow({
                     as={Input}
                     fullWidth
                     name={`[${outerArray}][${outerIndex}][${innerArray}].${itemIndex}`}
-                    suffix={
+                    renderSuffix={({ disabled }: PrefixSuffixRenderProps) => (
                       <RemoveInputSuffix
+                        disabled={disabled}
                         onClick={() => arrayHelpers.remove(itemIndex)}
                       />
-                    }
+                    )}
                   />
                 </div>
               ),

--- a/components/cv_form/personal_info.tsx
+++ b/components/cv_form/personal_info.tsx
@@ -75,7 +75,7 @@ export function PersonalInfo({ fProps, titles }: Props) {
         </div>
         <div className="md:flex-grow">
           <Field
-            className={inputClasses()}
+            className={inputClasses({ className: "text-gray-900" })}
             name="summary"
             type="text"
             as="textarea"

--- a/components/cv_form/personal_info.tsx
+++ b/components/cv_form/personal_info.tsx
@@ -1,5 +1,6 @@
 import { Field, ErrorMessage } from "formik";
 import type { TitlesResponse } from "../types";
+import Input, { inputClasses } from "@ui/input";
 
 interface Props {
   fProps: any;
@@ -18,7 +19,7 @@ export function PersonalInfo({ fProps, titles }: Props) {
         <div className="flex md:flex-grow">
           <div className="inline-block w-1/2 pr-1">
             <Field
-              className="w-full rounded-md"
+              as={Input}
               name="first_name"
               type="text"
               placeholder="First Name"
@@ -31,7 +32,7 @@ export function PersonalInfo({ fProps, titles }: Props) {
           </div>
           <div className="inline-block w-1/2 pl-1">
             <Field
-              className="w-full rounded-md"
+              as={Input}
               name="last_name"
               type="text"
               placeholder="Last Name"
@@ -74,7 +75,7 @@ export function PersonalInfo({ fProps, titles }: Props) {
         </div>
         <div className="md:flex-grow">
           <Field
-            className="w-full rounded-md"
+            className={inputClasses()}
             name="summary"
             type="text"
             as="textarea"

--- a/components/cv_form/projects.tsx
+++ b/components/cv_form/projects.tsx
@@ -50,7 +50,7 @@ export default function Projects({ fProps, setProjectsToRemove }: Props) {
                   <div className="md:flex-grow">
                     <Field
                       as="textarea"
-                      className={inputClasses()}
+                      className={inputClasses({ className: "text-gray-900" })}
                       name={`projects[${projectsIndex}].description`}
                       type="text"
                     />

--- a/components/cv_form/projects.tsx
+++ b/components/cv_form/projects.tsx
@@ -2,6 +2,7 @@ import { Field, FieldArray } from "formik";
 import * as Icons from "@ui/icons";
 import NestedRow from "./nested_row";
 import { MonthYearDatePicker } from "../datepicker";
+import Input, { inputClasses } from "@ui/input";
 
 interface Props {
   fProps: any;
@@ -32,6 +33,7 @@ export default function Projects({ fProps, setProjectsToRemove }: Props) {
                   </div>
                   <div className="md:flex-grow">
                     <Field
+                      as={Input}
                       className="w-full rounded-md"
                       name={`projects[${projectsIndex}].name`}
                       type="text"
@@ -47,10 +49,10 @@ export default function Projects({ fProps, setProjectsToRemove }: Props) {
                   </div>
                   <div className="md:flex-grow">
                     <Field
-                      className="w-full rounded-md"
+                      as="textarea"
+                      className={inputClasses()}
                       name={`projects[${projectsIndex}].description`}
                       type="text"
-                      as="textarea"
                     />
                   </div>
                 </div>
@@ -63,6 +65,7 @@ export default function Projects({ fProps, setProjectsToRemove }: Props) {
                   </div>
                   <div className="md:flex-grow">
                     <Field
+                      as={Input}
                       className="w-full rounded-md"
                       name={`projects[${projectsIndex}].field`}
                       type="text"
@@ -78,6 +81,7 @@ export default function Projects({ fProps, setProjectsToRemove }: Props) {
                   </div>
                   <div className="md:flex-grow">
                     <Field
+                      as={Input}
                       className="w-full rounded-md"
                       name={`projects[${projectsIndex}].team_size`}
                       type="text"
@@ -93,6 +97,7 @@ export default function Projects({ fProps, setProjectsToRemove }: Props) {
                   </div>
                   <div className="md:flex-grow">
                     <Field
+                      as={Input}
                       className="w-full rounded-md"
                       name={`projects[${projectsIndex}].position`}
                       type="text"
@@ -177,7 +182,7 @@ export default function Projects({ fProps, setProjectsToRemove }: Props) {
 
                 <div className="flex flex-wrap py-8 md:flex-nowrap">
                   <button
-                    className="flex text-indigo-500"
+                    className="flex gap-1 text-indigo-500"
                     type="button"
                     onClick={() => {
                       arrayHelpers.remove(projectsIndex);
@@ -194,7 +199,7 @@ export default function Projects({ fProps, setProjectsToRemove }: Props) {
               </div>
             ))}
           <button
-            className="flex flex-wrap text-indigo-500"
+            className="flex flex-wrap gap-1 text-indigo-500"
             type="button"
             onClick={() => arrayHelpers.push({})}
           >

--- a/components/cv_form/projects.tsx
+++ b/components/cv_form/projects.tsx
@@ -34,6 +34,7 @@ export default function Projects({ fProps, setProjectsToRemove }: Props) {
                   <div className="md:flex-grow">
                     <Field
                       as={Input}
+                      autoFocus
                       className="w-full rounded-md"
                       name={`projects[${projectsIndex}].name`}
                       type="text"

--- a/components/cv_form/remove_input_action.tsx
+++ b/components/cv_form/remove_input_action.tsx
@@ -1,0 +1,27 @@
+import { cx } from "class-variance-authority";
+import Button from "@ui/button";
+import { TrashCan } from "@ui/icons";
+
+interface RemoveInputActionProps {
+  disabled?: boolean;
+  onClick: React.MouseEventHandler<HTMLButtonElement>;
+}
+
+const RemoveInputAction = ({ disabled, onClick }: RemoveInputActionProps) => (
+  <Button
+    className={cx([
+      // add left border and remove radius
+      // + add 1px margin (width of border) so container's border is not overlapped on hover and focus
+      "m-px rounded-l-none border-l border-l-gray-300",
+      "focus:m-0 focus:border focus:border-indigo-300 focus:ring-4 focus:ring-indigo-100",
+    ])}
+    disabled={disabled}
+    onClick={onClick}
+    prefix={<TrashCan className="h-5 w-5" />}
+    variant="plain"
+  >
+    <span className="hidden sm:inline">Remove</span>
+  </Button>
+);
+
+export default RemoveInputAction;

--- a/components/datepicker.tsx
+++ b/components/datepicker.tsx
@@ -13,7 +13,7 @@ export function MonthYearDatePicker({ name, ...rest }: any) {
           <DateView
             {...field}
             {...rest}
-            className={inputClasses({ className: "w-auto" })}
+            className={inputClasses({ className: "w-auto text-gray-900" })}
             selected={value}
             onChange={(val: any) => setFieldValue(name, val)}
             dateFormat="MMMM yyyy"

--- a/components/datepicker.tsx
+++ b/components/datepicker.tsx
@@ -1,3 +1,4 @@
+import { inputClasses } from "@ui/input";
 import { Field } from "formik";
 import DateView from "react-datepicker";
 
@@ -12,6 +13,7 @@ export function MonthYearDatePicker({ name, ...rest }: any) {
           <DateView
             {...field}
             {...rest}
+            className={inputClasses({ className: "w-auto" })}
             selected={value}
             onChange={(val: any) => setFieldValue(name, val)}
             dateFormat="MMMM yyyy"

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -39,7 +39,7 @@ export const buttonClasses = cva(
           "disabled:hover:bg-white disabled:hover:text-gray-700",
         ],
         plain: [
-          "text-gray-600 focus:bg-gray-50",
+          "text-gray-600 focus:bg-gray-50 hover:text-gray-700",
           "hover:bg-gray-50 hover:text-gray-700",
           "disabled:hover:bg-transparent disabled:hover:text-gray-600",
         ],

--- a/components/ui/checkbox.tsx
+++ b/components/ui/checkbox.tsx
@@ -11,23 +11,11 @@ interface CheckboxProps {
   supportingText?: React.ReactNode;
 }
 
-const checkboxClasses = cva(
-  [
-    "checkbox h-5 w-5 rounded-md border-gray-300",
-    "focus:outline-0 focus:border-indigo-300 focus:ring-4 focus:ring-offset-0 focus:ring-indigo-100",
-  ],
-  {
-    variants: {
-      disabled: {
-        true: "text-gray-300",
-        false: "text-indigo-600",
-      },
-    },
-    defaultVariants: {
-      disabled: false,
-    },
-  },
-);
+export const checkboxClasses = cva([
+  "checkbox h-5 w-5 rounded-md border-gray-300 text-indigo-600",
+  "focus:border-indigo-300 focus:outline-0 focus:ring-4 focus:ring-indigo-100 focus:ring-offset-0",
+  "disabled:text-gray-300",
+]);
 
 const Checkbox = ({
   checked,
@@ -43,7 +31,7 @@ const Checkbox = ({
       <div className="flex h-5 items-center">
         <input
           checked={checked}
-          className={checkboxClasses({ disabled, className })}
+          className={checkboxClasses({ className })}
           disabled={disabled}
           id={name}
           name={name}

--- a/components/ui/icons.tsx
+++ b/components/ui/icons.tsx
@@ -2,14 +2,14 @@ interface IconProps {
   className?: string;
 }
 
-export const TrashCan = () => (
+export const TrashCan = ({ className = "h-6 w-6" }: IconProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
     strokeWidth={1.5}
     stroke="currentColor"
-    className="h-6 w-6"
+    className={className}
   >
     <path
       strokeLinecap="round"

--- a/components/ui/icons.tsx
+++ b/components/ui/icons.tsx
@@ -19,14 +19,14 @@ export const TrashCan = ({ className = "h-6 w-6" }: IconProps) => (
   </svg>
 );
 
-export const PlusCircle = () => (
+export const PlusCircle = ({ className = "h-6 w-6" }: IconProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     fill="none"
     viewBox="0 0 24 24"
     strokeWidth={1.5}
     stroke="currentColor"
-    className="h-6 w-6"
+    className={className}
   >
     <path
       strokeLinecap="round"

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -58,6 +58,21 @@ export const inputClasses = cva(
   },
 );
 
+function getElementWidth<RefType extends HTMLElement | null>(
+  elementRef: React.MutableRefObject<RefType>,
+) {
+  if (!elementRef?.current) {
+    return "";
+  }
+
+  const spacingBetweenElementAndIndex = 4;
+
+  return (
+    Math.round(elementRef.current.getBoundingClientRect().width || 0) +
+    spacingBetweenElementAndIndex
+  );
+}
+
 const Input = React.forwardRef(
   (
     {
@@ -75,15 +90,11 @@ const Input = React.forwardRef(
     }: InputProps,
     ref: React.Ref<HTMLInputElement>,
   ) => {
-    const prefixRef = useRef<HTMLSpanElement>(null);
-    const suffixRef = useRef<HTMLSpanElement>(null);
+    const prefixRef = useRef<HTMLSpanElement | null>(null);
+    const suffixRef = useRef<HTMLSpanElement | null>(null);
 
-    const inputPaddingLeft = prefixRef.current
-      ? Math.round(prefixRef.current.getBoundingClientRect().width) + 4
-      : "";
-    const inputPaddingRight = suffixRef.current
-      ? Math.round(suffixRef.current.getBoundingClientRect().width) + 4
-      : "";
+    const inputPaddingLeft = getElementWidth(prefixRef);
+    const inputPaddingRight = getElementWidth(suffixRef);
 
     const prefixPresent = typeof renderPrefix === "function";
     const suffixPresent = typeof renderSuffix === "function";

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -16,7 +16,7 @@ interface InputProps
   suffix?: React.ReactElement;
 }
 
-const containerClasses = cva("relative rounded-md", {
+const inputContainerClasses = cva("relative rounded-md", {
   variants: {
     fullWidth: {
       true: "w-full",
@@ -76,7 +76,7 @@ const Input = React.forwardRef(
     ref: React.Ref<HTMLInputElement>,
   ) => {
     return (
-      <div>
+      <div className={cx(fullWidth ? "w-full" : "")}>
         <label
           htmlFor={name}
           className="block text-sm font-medium text-gray-700"
@@ -86,7 +86,7 @@ const Input = React.forwardRef(
 
         <div
           className={cx([
-            containerClasses({
+            inputContainerClasses({
               className,
               disabled,
               fullWidth,

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,18 +1,19 @@
 import React, { useRef } from "react";
 import { cva, cx } from "class-variance-authority";
 
+export interface PrefixSuffixRenderProps {
+  disabled?: boolean;
+}
+
 interface InputProps
-  extends Omit<
-    React.DetailedHTMLProps<
-      React.InputHTMLAttributes<HTMLInputElement>,
-      HTMLInputElement
-    >,
-    "prefix"
+  extends React.DetailedHTMLProps<
+    React.InputHTMLAttributes<HTMLInputElement>,
+    HTMLInputElement
   > {
   fullWidth?: boolean;
   helperText?: React.ReactElement;
-  prefix?: React.ReactElement;
-  suffix?: React.ReactElement;
+  renderPrefix?: ({ disabled }: PrefixSuffixRenderProps) => React.ReactElement;
+  renderSuffix?: ({ disabled }: PrefixSuffixRenderProps) => React.ReactElement;
 }
 
 const inputContainerClasses = cva("relative rounded-md", {
@@ -67,8 +68,8 @@ const Input = React.forwardRef(
       helperText,
       name,
       id = name,
-      prefix,
-      suffix,
+      renderPrefix,
+      renderSuffix,
       type = "text",
       ...restProps
     }: InputProps,
@@ -83,6 +84,9 @@ const Input = React.forwardRef(
     const inputPaddingRight = suffixRef.current
       ? Math.round(suffixRef.current.getBoundingClientRect().width) + 4
       : "";
+
+    const prefixPresent = typeof renderPrefix === "function";
+    const suffixPresent = typeof renderSuffix === "function";
 
     return (
       <div className={cx(fullWidth ? "w-full" : "")}>
@@ -103,12 +107,12 @@ const Input = React.forwardRef(
             }),
           ])}
         >
-          {prefix ? (
+          {prefixPresent ? (
             <span
-              className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3"
+              className="pointer-events-none absolute inset-y-0 left-0 flex items-center"
               ref={prefixRef}
             >
-              <prefix.type {...prefix.props} />
+              {renderPrefix({ disabled })}
             </span>
           ) : null}
 
@@ -122,19 +126,19 @@ const Input = React.forwardRef(
             id={id}
             disabled={disabled}
             className={inputClasses({
-              hasPrefix: !!prefix,
-              hasSuffix: !!suffix,
+              hasPrefix: prefixPresent,
+              hasSuffix: suffixPresent,
             })}
             ref={ref}
             {...restProps}
           />
 
-          {suffix ? (
+          {suffixPresent ? (
             <span
               className="absolute inset-y-0 right-0 flex items-center"
               ref={suffixRef}
             >
-              <suffix.type {...suffix.props} />
+              {renderSuffix({ disabled })}
             </span>
           ) : null}
         </div>

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,6 +1,5 @@
 import React from "react";
 import { cva, cx } from "class-variance-authority";
-import { omit } from "../../utils/object";
 
 interface InputProps
   extends Omit<
@@ -95,13 +94,9 @@ const Input = React.forwardRef(
           ])}
         >
           {prefix ? (
-            <prefix.type
-              className={cx(
-                "pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3",
-                prefix.props.className,
-              )}
-              {...omit(prefix.props, "className")}
-            />
+            <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+              <prefix.type {...prefix.props} />
+            </span>
           ) : null}
 
           <input
@@ -118,13 +113,9 @@ const Input = React.forwardRef(
           />
 
           {suffix ? (
-            <suffix.type
-              className={cx(
-                "absolute inset-y-0 right-0 flex items-center",
-                suffix.props.className,
-              )}
-              {...omit(suffix.props, "className")}
-            />
+            <span className="absolute inset-y-0 right-0 flex items-center">
+              <suffix.type {...suffix.props} />
+            </span>
           ) : null}
         </div>
 

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,0 +1,140 @@
+import React from "react";
+import { cva, cx } from "class-variance-authority";
+import { omit } from "../../utils/object";
+
+interface InputProps
+  extends Omit<
+    React.DetailedHTMLProps<
+      React.InputHTMLAttributes<HTMLInputElement>,
+      HTMLInputElement
+    >,
+    "prefix"
+  > {
+  fullWidth?: boolean;
+  helperText?: React.ReactElement;
+  prefix?: React.ReactElement;
+  suffix?: React.ReactElement;
+}
+
+const containerClasses = cva("relative rounded-md", {
+  variants: {
+    fullWidth: {
+      true: "w-full",
+    },
+    disabled: {
+      true: "bg-gray-50 text-gray-300",
+      false: "text-gray-900",
+    },
+    hasLabel: {
+      true: "mt-1.5",
+      false: "",
+    },
+  },
+  defaultVariants: {
+    fullWidth: false,
+    disabled: false,
+    hasLabel: false,
+  },
+});
+
+export const inputClasses = cva(
+  [
+    "block w-full rounded-md border border-gray-300 py-2 shadow-sm bg-transparent placeholder:text-gray-500",
+    "focus:border-indigo-300 focus:outline-0 focus:ring-4 focus:ring-indigo-100 focus:ring-offset-0",
+  ],
+  {
+    variants: {
+      hasPrefix: {
+        true: "pl-3",
+      },
+      hasSuffix: {
+        true: "pr-3",
+      },
+    },
+    defaultVariants: {
+      hasPrefix: false,
+      hasSuffix: false,
+    },
+  },
+);
+
+const Input = React.forwardRef(
+  (
+    {
+      children,
+      className,
+      disabled,
+      fullWidth,
+      helperText,
+      name,
+      id = name,
+      prefix,
+      suffix,
+      type = "text",
+      ...restProps
+    }: InputProps,
+    ref: React.Ref<HTMLInputElement>,
+  ) => {
+    return (
+      <div>
+        <label
+          htmlFor={name}
+          className="block text-sm font-medium text-gray-700"
+        >
+          {children}
+        </label>
+
+        <div
+          className={cx([
+            containerClasses({
+              className,
+              disabled,
+              fullWidth,
+              hasLabel: !!children,
+            }),
+          ])}
+        >
+          {prefix ? (
+            <prefix.type
+              className={cx(
+                "pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3",
+                prefix.props.className,
+              )}
+              {...omit(prefix.props, "className")}
+            />
+          ) : null}
+
+          <input
+            type={type}
+            name={name}
+            id={id}
+            disabled={disabled}
+            className={inputClasses({
+              hasPrefix: !!prefix,
+              hasSuffix: !!suffix,
+            })}
+            ref={ref}
+            {...restProps}
+          />
+
+          {suffix ? (
+            <suffix.type
+              className={cx(
+                "absolute inset-y-0 right-0 flex items-center",
+                suffix.props.className,
+              )}
+              {...omit(suffix.props, "className")}
+            />
+          ) : null}
+        </div>
+
+        {helperText ? (
+          <div className="mt-1.5 text-sm text-gray-600">{helperText}</div>
+        ) : null}
+      </div>
+    );
+  },
+);
+Input.displayName = "Input";
+
+export default Input;

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useRef } from "react";
 import { cva, cx } from "class-variance-authority";
 
 interface InputProps
@@ -74,6 +74,16 @@ const Input = React.forwardRef(
     }: InputProps,
     ref: React.Ref<HTMLInputElement>,
   ) => {
+    const prefixRef = useRef<HTMLSpanElement>(null);
+    const suffixRef = useRef<HTMLSpanElement>(null);
+
+    const inputPaddingLeft = prefixRef.current
+      ? Math.round(prefixRef.current.getBoundingClientRect().width) + 4
+      : "";
+    const inputPaddingRight = suffixRef.current
+      ? Math.round(suffixRef.current.getBoundingClientRect().width) + 4
+      : "";
+
     return (
       <div className={cx(fullWidth ? "w-full" : "")}>
         <label
@@ -94,12 +104,19 @@ const Input = React.forwardRef(
           ])}
         >
           {prefix ? (
-            <span className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
+            <span
+              className="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3"
+              ref={prefixRef}
+            >
               <prefix.type {...prefix.props} />
             </span>
           ) : null}
 
           <input
+            style={{
+              paddingLeft: inputPaddingLeft,
+              paddingRight: inputPaddingRight,
+            }}
             type={type}
             name={name}
             id={id}
@@ -113,7 +130,10 @@ const Input = React.forwardRef(
           />
 
           {suffix ? (
-            <span className="absolute inset-y-0 right-0 flex items-center">
+            <span
+              className="absolute inset-y-0 right-0 flex items-center"
+              ref={suffixRef}
+            >
               <suffix.type {...suffix.props} />
             </span>
           ) : null}

--- a/utils/object.ts
+++ b/utils/object.ts
@@ -1,0 +1,28 @@
+export function omit(
+  obj: Record<string, unknown>,
+  keys: string | string[],
+): Record<string, unknown> {
+  if (!obj || typeof obj !== "object") {
+    throw new TypeError("Expected first argument to be an object");
+  }
+
+  const keysToOmit = typeof keys === "string" ? [keys] : keys;
+
+  if (!Array.isArray(keysToOmit)) {
+    throw new TypeError("Expected second argument to be an array or string");
+  }
+
+  if (keysToOmit.some((key) => typeof key !== "string")) {
+    throw new TypeError("Expected keys to be an array of strings");
+  }
+
+  const result: Record<string, unknown> = {};
+
+  for (const key of Object.keys(obj)) {
+    if (!keysToOmit.includes(key)) {
+      result[key] = obj[key];
+    }
+  }
+
+  return result;
+}


### PR DESCRIPTION
In this PR is added Input component and used in places where `input` was used.

In this PR are updated text textarea components as well - they at the moment (until separate `TextArea` component is created) are using class names of input component.

### Screenshot
<img width="1070" alt="image" src="https://user-images.githubusercontent.com/11313640/229516159-d856a7d2-0218-4641-b198-38fb21352e4b.png">
