### PR TITLE
fix file names

### DIFF
--- a/pages/api/upload_to_drive.ts
+++ b/pages/api/upload_to_drive.ts
@@ -62,7 +62,6 @@ async function uploadFile(
   async function resolveFileNameForDrive(initialFileName: string): Promise<string> {
     let currentFileName = initialFileName;
     let uniqueFileNameGenerated = false;
-    let i = 0;
     // Underscore followed by at least one number
     const regex = /_([0-9]+)$/;
     // Below code generates unique file name, adding _1,_2,... until it finds the version that does not exist

--- a/pages/api/upload_to_drive.ts
+++ b/pages/api/upload_to_drive.ts
@@ -63,6 +63,8 @@ async function uploadFile(
     let currentFileName = initialFileName;
     let uniqueFileNameGenerated = false;
     let i = 0;
+    // Underscore followed by at least one number
+    const regex = /_[0-9]+/g;
     // Below code generates unique file name, adding _1,_2,... until it finds the version that does not exist
     while (!uniqueFileNameGenerated) {
       const filesListResponse = await driveService.files.list({
@@ -72,8 +74,13 @@ async function uploadFile(
       });
 
       if (filesListResponse.data.files && filesListResponse.data.files.length > 0) {
-        const endIndex = currentFileName.indexOf('_') != -1 ? currentFileName.indexOf('_') : currentFileName.length
-        currentFileName = currentFileName.substring(0, endIndex) + '_' + ++i;
+        // Check if filename has _1, _2,... and if it has, increment the number at the end
+        let matches = currentFileName.match(regex);
+        if (matches) {
+          const lastMatch = matches[matches.length - 1];
+          const lastIndex = currentFileName.lastIndexOf(lastMatch);
+          currentFileName = currentFileName.substring(0, lastIndex) + '_' + ++i;
+        }
       } else {
         uniqueFileNameGenerated = true;
       }

--- a/pages/api/upload_to_drive.ts
+++ b/pages/api/upload_to_drive.ts
@@ -75,7 +75,7 @@ async function uploadFile(
 
       if (filesListResponse.data.files && filesListResponse.data.files.length > 0) {
         // Check if filename has _1, _2,... and if it has, increment the number at the end
-        let matches = currentFileName.match(regex);
+        const matches = currentFileName.match(regex);
         let lastIndex = -1;
         if (matches) {
           const lastMatch = matches[matches.length - 1];

--- a/pages/api/upload_to_drive.ts
+++ b/pages/api/upload_to_drive.ts
@@ -64,7 +64,7 @@ async function uploadFile(
     let uniqueFileNameGenerated = false;
     let i = 0;
     // Underscore followed by at least one number
-    const regex = /_[0-9]+/g;
+    const regex = /_([0-9]+)$/;
     // Below code generates unique file name, adding _1,_2,... until it finds the version that does not exist
     while (!uniqueFileNameGenerated) {
       const filesListResponse = await driveService.files.list({
@@ -75,16 +75,10 @@ async function uploadFile(
 
       if (filesListResponse.data.files && filesListResponse.data.files.length > 0) {
         // Check if filename has _1, _2,... and if it has, increment the number at the end
-        const matches = currentFileName.match(regex);
-        let lastIndex = -1;
-        if (matches) {
-          const lastMatch = matches[matches.length - 1];
-          lastIndex = currentFileName.lastIndexOf(lastMatch);
-        }
-        if (lastIndex > -1) {
-          currentFileName = currentFileName.substring(0, lastIndex) + '_' + ++i;
+        if (currentFileName.match(regex)) {
+          currentFileName = currentFileName.replace(regex, (_, number) => `_${parseInt(number) + 1}`);
         } else {
-          currentFileName += currentFileName + '_' + ++i;
+          currentFileName += "_1"
         }
       } else {
         uniqueFileNameGenerated = true;

--- a/pages/api/upload_to_drive.ts
+++ b/pages/api/upload_to_drive.ts
@@ -76,10 +76,15 @@ async function uploadFile(
       if (filesListResponse.data.files && filesListResponse.data.files.length > 0) {
         // Check if filename has _1, _2,... and if it has, increment the number at the end
         let matches = currentFileName.match(regex);
+        let lastIndex = -1;
         if (matches) {
           const lastMatch = matches[matches.length - 1];
-          const lastIndex = currentFileName.lastIndexOf(lastMatch);
+          lastIndex = currentFileName.lastIndexOf(lastMatch);
+        }
+        if (lastIndex > -1) {
           currentFileName = currentFileName.substring(0, lastIndex) + '_' + ++i;
+        } else {
+          currentFileName += currentFileName + '_' + ++i;
         }
       } else {
         uniqueFileNameGenerated = true;


### PR DESCRIPTION
The first solution was not working because it was just looking for an underscore, but the filename format changed in the meantime, and we had multiple underscores in our filename. This solution uses regex to find the last occurrence of _%d (underscore followed by a number).